### PR TITLE
Fix weighted power by using proper rolling window

### DIFF
--- a/plugin/core/scripts/processors/activity-computer.ts
+++ b/plugin/core/scripts/processors/activity-computer.ts
@@ -38,7 +38,7 @@ export class ActivityComputer {
 	public static readonly GRADE_PROFILE_FLAT: string = "FLAT";
 	public static readonly GRADE_PROFILE_HILLY: string = "HILLY";
 	public static readonly ASCENT_SPEED_GRADE_LIMIT: number = ActivityComputer.GRADE_CLIMBING_LIMIT;
-	public static readonly AVG_POWER_TIME_WINDOW_SIZE: number = 60; // Seconds
+	public static readonly AVG_POWER_TIME_WINDOW_SIZE: number = 30; // Seconds
 	public static readonly SPLIT_MAX_SCALE_TIME_GAP_THRESHOLD: number = 60 * 60 * 12; // 12 hours
 
 	protected athleteModel: AthleteModel;
@@ -647,64 +647,60 @@ export class ActivityComputer {
 		let durationInSeconds: number;
 		let totalMovingInSeconds = 0;
 
-		let timeWindowValue = 0;
-		let sumPowerTimeWindow: number[] = [];
-		const sum4thPower: number[] = [];
+		let rollingWindowSize = 0;
+		let rollingIndex = 0;
+		let sum4thPower = 0;
 
-		for (let i = 0; i < powerArray.length; i++) { // Loop on samples
+		let rollingSum = (powerArray.length > 0 ? powerArray[0] : 0);
+		let totalMovingSamples = 1;
 
-			if ((this.isTrainer || !velocityArray || _.isNumber(velocityArray[i])) && i > 0) {
+		for (let i = 1; i < powerArray.length; i++) { // Loop on samples
+			if (!(this.isTrainer || !velocityArray || _.isNumber(velocityArray[i]))) {
+				continue;
+			}
 
-				// Compute distribution for graph/table
-				durationInSeconds = (timeArray[i] - timeArray[i - 1]); // Getting deltaTime in seconds (current sample and previous one)
+			// Compute distribution for graph/table
+			durationInSeconds = (timeArray[i] - timeArray[i - 1]); // Getting deltaTime in seconds (current sample and previous one)
 
-				// When speed data is given. then totalMovingInSeconds value increase only if athlete is moving
-				if (velocityArray) {
-					if (velocityArray[i] * 3.6 > ActivityComputer.MOVING_THRESHOLD_KPH) {
-						totalMovingInSeconds += durationInSeconds;
-					}
-				} else {
-					totalMovingInSeconds += durationInSeconds;
-				}
+			rollingSum += powerArray[i];
+			rollingWindowSize += durationInSeconds;
 
-				timeWindowValue += durationInSeconds; // Add seconds to time buffer
-				sumPowerTimeWindow.push(powerArray[i]); // Add power value
+			sum4thPower += Math.pow(rollingSum/(i - rollingIndex + 1), 4);
 
-				if (timeWindowValue >= ActivityComputer.AVG_POWER_TIME_WINDOW_SIZE) {
+			// Reduce rolling window size if necessary. This is a bit
+			// complicated as we don't know a priori how many samples to
+			// remove from the beginning of the window as the delta time
+			// between samples varies.
+			while (rollingWindowSize >= ActivityComputer.AVG_POWER_TIME_WINDOW_SIZE) {
+				rollingSum -= powerArray[rollingIndex];
+				rollingWindowSize -= (timeArray[rollingIndex+1] - timeArray[rollingIndex]);
+				rollingIndex++;
+			}
 
-					// Get average of power during these 60 seconds windows & power 4th
-					const sumPower = _.reduce(sumPowerTimeWindow, (a: number, b: number) => { // The reduce function and implementation return the sum of array
-						return (a + b);
-					}, 0) / sumPowerTimeWindow.length;
+			// When speed data is given, totalMovingInSeconds value increases only if athlete is moving
+			if (!velocityArray || (velocityArray[i] * 3.6 > ActivityComputer.MOVING_THRESHOLD_KPH)) {
+				totalMovingInSeconds += durationInSeconds;
+				totalMovingSamples++;
+			}
 
-					sum4thPower.push(Math.pow(sumPower, 4));
+			wattsSamplesOnMove.push(powerArray[i]);
+			wattsSamplesOnMoveDuration.push(durationInSeconds);
 
-					timeWindowValue = 0; // Reset time window
-					sumPowerTimeWindow = []; // Reset sum of power window
-				}
+			// average over time
+			accumulatedWattsOnMove += this.discreteValueBetween(powerArray[i], powerArray[i - 1], durationInSeconds);
+			wattSampleOnMoveCount += durationInSeconds;
 
-				wattsSamplesOnMove.push(powerArray[i]);
-				wattsSamplesOnMoveDuration.push(durationInSeconds);
+			const powerZoneId: number = this.getZoneId(powerZonesAlongActivityType, powerArray[i]);
 
-				// average over time
-				accumulatedWattsOnMove += this.discreteValueBetween(powerArray[i], powerArray[i - 1], durationInSeconds);
-				wattSampleOnMoveCount += durationInSeconds;
-
-				const powerZoneId: number = this.getZoneId(powerZonesAlongActivityType, powerArray[i]);
-
-				if (!_.isUndefined(powerZoneId) && !_.isUndefined(powerZonesAlongActivityType[powerZoneId])) {
-					powerZonesAlongActivityType[powerZoneId].s += durationInSeconds;
-				}
+			if (!_.isUndefined(powerZoneId) && !_.isUndefined(powerZonesAlongActivityType[powerZoneId])) {
+				powerZonesAlongActivityType[powerZoneId].s += durationInSeconds;
 			}
 		}
 
 		// Finalize compute of Power
 		const avgWatts: number = _.mean(powerArray);
 
-		const weightedPower = Math.sqrt(Math.sqrt(_.reduce(sum4thPower, (a: number, b: number) => { // The reduce function and implementation return the sum of array
-			return (a + b);
-		}, 0) / sum4thPower.length));
-
+		const weightedPower = Math.sqrt(Math.sqrt(sum4thPower/totalMovingSamples));
 
 		const variabilityIndex: number = weightedPower / avgWatts;
 		const intensity: number = (_.isNumber(cyclingFtp) && cyclingFtp > 0) ? (weightedPower / cyclingFtp) : null;

--- a/plugin/core/specs/processors/activity-computing/activity-computer-power.spec.ts
+++ b/plugin/core/specs/processors/activity-computing/activity-computer-power.spec.ts
@@ -77,7 +77,7 @@ describe("ActivityComputer Cycling Power", () => {
 
 		// Then
 		expectBetween(result.powerData.avgWatts, 208, TOLERANCE);
-		expectBetween(_.floor(result.powerData.weightedPower), 258, TOLERANCE);
+		expectBetween(_.floor(result.powerData.weightedPower), 265, TOLERANCE);
 		expectBetween(_.floor(result.powerData.best20min), 380, TOLERANCE);
 
 		done();

--- a/plugin/core/specs/processors/activity-computing/activity-computer.spec.ts
+++ b/plugin/core/specs/processors/activity-computing/activity-computer.spec.ts
@@ -92,7 +92,7 @@ describe("ActivityComputer", () => {
 
 		expect(result.powerData.hasPowerMeter).toEqual(false);
 		expect(result.powerData.avgWatts.toString()).toMatch(/^210.68/);
-		expect(result.powerData.weightedPower.toString()).toMatch(/^235.59/);
+		expect(result.powerData.weightedPower.toString()).toMatch(/^244.66/);
 
 		expect(result.heartRateData.TRIMP.toString()).toMatch(/^228.48086657/);
 		expect(result.heartRateData.TRIMPPerHour.toString()).toMatch(/^134.2688736/);


### PR DESCRIPTION
Fix #658.

@thomaschampagne This is work in progress. Just wanted to show you what I'm thinking. Btw, is there a way to quickly recalculate the metrics without clearing all activities in the plugin? 

I also have several questions:
1. [Here](https://github.com/thomaschampagne/elevate/blob/12ba302446529c9c53def2a35b19ec967558574b/plugin/core/scripts/processors/activity-computer.ts#L659) Am I right assuming that the delta time between too samples may not be consistent? I.e., it could be of different length between different samples? I assume that that is the case for Garmin watches in Smart mode, for example.
2. What's the right way to treat non-moving samples? Should I just ignore them completely, or continue rolling window through them? If the stopped interval is long, the average will automatically become zero. However, depending on the approach, there will be some differences in averages in the first several samples after stopping. My preference is roll through them.
3. Could you please explain the logic behind [this](	https://github.com/thomaschampagne/elevate/blob/12ba302446529c9c53def2a35b19ec967558574b/plugin/core/scripts/processors/activity-computer.ts#L656) check?
4. In the other issue, you mentioned 60s vs 30s interval. Why was it changed?