### PR TITLE
Feature: Add links to legend activities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "elevate",
-	"version": "6.7.0",
+	"version": "6.8.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1109,19 +1109,18 @@
 			"dev": true
 		},
 		"event-stream": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-			"integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
 			"dev": true,
 			"requires": {
-				"duplexer": "^0.1.1",
-				"flatmap-stream": "^0.1.0",
-				"from": "^0.1.7",
-				"map-stream": "0.0.7",
-				"pause-stream": "^0.0.11",
-				"split": "^1.0.1",
-				"stream-combiner": "^0.2.2",
-				"through": "^2.3.8"
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
 			}
 		},
 		"execa": {
@@ -1316,12 +1315,6 @@
 			"requires": {
 				"locate-path": "^3.0.0"
 			}
-		},
-		"flatmap-stream": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-			"integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
-			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -2066,9 +2059,9 @@
 			"dev": true
 		},
 		"map-stream": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-			"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+			"version": "0.1.0",
+			"resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
 			"dev": true
 		},
 		"map-visit": {
@@ -3099,9 +3092,9 @@
 			"dev": true
 		},
 		"split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"version": "0.3.3",
+			"resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
 			"dev": true,
 			"requires": {
 				"through": "2"
@@ -3138,13 +3131,12 @@
 			}
 		},
 		"stream-combiner": {
-			"version": "0.2.2",
-			"resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-			"integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+			"version": "0.0.4",
+			"resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
 			"dev": true,
 			"requires": {
-				"duplexer": "~0.1.1",
-				"through": "~2.3.4"
+				"duplexer": "~0.1.1"
 			}
 		},
 		"string-width": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 	"license": "MIT",
 	"readme": "README.md",
 	"devDependencies": {
+		"event-stream": "3.3.4",
 		"bestzip": "^2.1.2",
 		"cpy-cli": "^2.0.0",
 		"del-cli": "^1.1.0",

--- a/plugin/app/package-lock.json
+++ b/plugin/app/package-lock.json
@@ -762,6 +762,9 @@
 				}
 			}
 		},
+		"@elevate/shared": {
+			"version": "file:modules/shared"
+		},
 		"@iktakahiro/markdown-it-katex": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@iktakahiro/markdown-it-katex/-/markdown-it-katex-3.0.4.tgz",

--- a/plugin/app/package.json
+++ b/plugin/app/package.json
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^7.0.4",
     "@angular/platform-browser-dynamic": "^7.0.4",
     "@angular/router": "^7.0.4",
-	"@elevate/shared": "file:modules/shared",
+    "@elevate/shared": "file:modules/shared",
     "@iktakahiro/markdown-it-katex": "^3.0.4",
     "core-js": "^2.5.4",
     "d3": "^5.7.0",

--- a/plugin/app/src/app/fitness-trend/fitness-trend-graph/fitness-trend-graph.component.ts
+++ b/plugin/app/src/app/fitness-trend/fitness-trend-graph/fitness-trend-graph.component.ts
@@ -417,7 +417,7 @@ export class FitnessTrendGraphComponent implements OnInit, OnChanges, OnDestroy 
 	}
 
 	public onGraphMouseOut(date: Date): void {
-		this.setTodayAsViewedDay();
+		//this.setTodayAsViewedDay();
 	}
 
 	public getTodayViewedDay(): DayFitnessTrendModel {

--- a/plugin/app/src/app/fitness-trend/fitness-trend-legend/fitness-trend-legend.component.html
+++ b/plugin/app/src/app/fitness-trend/fitness-trend-legend/fitness-trend-legend.component.html
@@ -8,7 +8,7 @@
 		 class="legend-active-day">
 			<span *ngSwitchCase="true">
 				<span *ngFor="let activity of viewedDay.activitiesName; let activityIndex = index;">
-					<span *ngIf="(activityIndex < MAX_ACTIVITIES_LEGEND_SHOWN)" (click)="onOpenActivity(viewedDay.ids[activityIndex])">
+					<span *ngIf="(activityIndex < MAX_ACTIVITIES_LEGEND_SHOWN)" class="button" (click)="onOpenActivity(viewedDay.ids[activityIndex])">
 						<span class="tag">{{viewedDay.types[activityIndex]}}</span>
 						<span class="name"> {{activity | shorten: ((viewedDay.activitiesName.length > 1) ? MAX_MULTIPLE_ACTIVITIES_CHAR_COUNT_DISPLAYED : MAX_SINGLE_ACTIVITY_CHAR_COUNT_DISPLAYED) : "..."}}</span>
 						<span *ngIf="(viewedDay.activitiesName.length !== (activityIndex + 1))">;&nbsp;&nbsp;</span>

--- a/plugin/app/src/app/fitness-trend/fitness-trend-legend/fitness-trend-legend.component.html
+++ b/plugin/app/src/app/fitness-trend/fitness-trend-legend/fitness-trend-legend.component.html
@@ -8,7 +8,7 @@
 		 class="legend-active-day">
 			<span *ngSwitchCase="true">
 				<span *ngFor="let activity of viewedDay.activitiesName; let activityIndex = index;">
-					<span *ngIf="(activityIndex < MAX_ACTIVITIES_LEGEND_SHOWN)">
+					<span *ngIf="(activityIndex < MAX_ACTIVITIES_LEGEND_SHOWN)" (click)="onOpenActivity(viewedDay.ids[activityIndex])">
 						<span class="tag">{{viewedDay.types[activityIndex]}}</span>
 						<span class="name"> {{activity | shorten: ((viewedDay.activitiesName.length > 1) ? MAX_MULTIPLE_ACTIVITIES_CHAR_COUNT_DISPLAYED : MAX_SINGLE_ACTIVITY_CHAR_COUNT_DISPLAYED) : "..."}}</span>
 						<span *ngIf="(viewedDay.activitiesName.length !== (activityIndex + 1))">;&nbsp;&nbsp;</span>

--- a/plugin/app/src/app/fitness-trend/fitness-trend-legend/fitness-trend-legend.component.ts
+++ b/plugin/app/src/app/fitness-trend/fitness-trend-legend/fitness-trend-legend.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnDestroy, OnInit } from "@angular/core";
 import { DayFitnessTrendModel } from "../shared/models/day-fitness-trend.model";
 import { ViewedDayService } from "../shared/services/viewed-day.service";
 import { Subscription } from "rxjs";
+import { FitnessTrendComponent } from "../fitness-trend.component";
 
 @Component({
 	selector: "app-fitness-trend-legend",
@@ -31,5 +32,9 @@ export class FitnessTrendLegendComponent implements OnInit, OnDestroy {
 
 	public ngOnDestroy(): void {
 		this.subscription.unsubscribe();
+	}
+
+	public onOpenActivity(id: number): void {
+		FitnessTrendComponent.openActivities([ id ]);
 	}
 }

--- a/plugin/app/src/app/fitness-trend/fitness-trend.component.theme.scss
+++ b/plugin/app/src/app/fitness-trend/fitness-trend.component.theme.scss
@@ -39,6 +39,10 @@ $config: mat-typography-config();
 		.name {
 			color: $accent-color;
 		}
+
+		.button {
+			cursor: pointer;
+		}
 	}
 
 	.atl-value {


### PR DESCRIPTION
Let me begin by saying that Node.js and Chrome extensions are definitely not my domain, so I am offering this PR on a best-effort basis.  

Commit 2ae6557 was necessary because event-stream@3.3.6 could not be found when I ran `npm install`.  I believe that version included a backdoor or other major vulnerability and was pulled from NPM.  I don't know if my approach here was correct (I suspect some of the changes in that commit are unwanted), but it unblocked me and allowed for the installation of dependencies.

The actual feature-related changes were pretty minimal, but I was unable to test them.  When I am using the published extension (from the Chrome Web Store), I can move the mouse out of the graph and the legend remains populated with the activities from whichever day I was on before moving the mouse out of the graph.  Strangely, this is not the case when I build and load the extension locally.  For my version (even before my changes), the legend clears when I move the mouse out of the grid.  No errors are logged in the dev console or chrome://extensions dashboard.  I also tried `npm run build:prod`, but that made no difference.

Anyways, the proposed feature is pretty straightforward.  It would be great if the activities in the fitness trend legend were links so a user could click to open that specific activity from the legend (rather than clicking the graph to open all activities on a given day, or scrolling down to find the activity in the table).  I keep finding myself trying to click an activity in the legend, so it just felt like the links should intuitively be there but they were missing.

Feel free to use part or all of this PR, or perhaps implement completely differently.  In any case, I'd love to see this change included in a future version.  

Thanks for the amazing project!