### PR TITLE
Fix minor grammar issue and change warning icon to warn colour

### DIFF
--- a/plugin/app/src/app/athlete-settings/components/dated-athlete-settings-manager/dated-athlete-settings-manager.component.html
+++ b/plugin/app/src/app/athlete-settings/components/dated-athlete-settings-manager/dated-athlete-settings-manager.component.html
@@ -7,7 +7,7 @@
 		<div>
 			<strong>Why Dated Athlete Settings?</strong> Currently <a
 			href="https://support.strava.com/hc/en-us/community/posts/203479564-Changing-FTP-changes-all-previous-training-score-data"
-			target="_blank">Strava do not support</a> evolution of your physiological attributes over time (heart
+			target="_blank">Strava does not support</a> evolution of your physiological attributes over time (heart
 			rate, weight, power, pace, ...). They have to be supported because activities' stats including stress
 			scores are functions of these attributes. After configuration by yourself, this feature will provide
 			matching athlete's attributes for a given activity date to calculate stats with actual day's attributes.
@@ -16,7 +16,7 @@
 		</div>
 
 		<div>
-			<mat-icon color="primary" [style.vertical-align]="'middle'">warning</mat-icon>
+			<mat-icon color="warn" [style.vertical-align]="'middle'">warning</mat-icon>
 			<strong>Dated Athlete Settings</strong> might change along updates. These settings are currently saved
 			locally and they not synced between computers for technicals reasons (chrome sync api limitations). They
 			will be online synced in a near future using a dedicated service. By the way, Dated Athlete Settings are


### PR DESCRIPTION
This warning icon seemed to be the only one in the application which didn't use the warn colour.  It looked fine in yellow on the classic dark theme, but seemed out of place on most other themes (including the classic light theme).

![image](https://user-images.githubusercontent.com/648035/50604830-0dfa9800-0e75-11e9-8803-b1be3d17e094.png)
