### PR TITLE
Add MomentDateAdapter to solve shifting dates issue; fixes #705

### DIFF
--- a/plugin/app/package-lock.json
+++ b/plugin/app/package-lock.json
@@ -601,6 +601,14 @@
         "tslib": "^1.7.1"
       }
     },
+    "@angular/material-moment-adapter": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/material-moment-adapter/-/material-moment-adapter-7.2.0.tgz",
+      "integrity": "sha512-/mpXYfoQ+MHq8x7lBltVtqQcVf/wJxWIqPFHDsKMXp4qXMNZwqf9mnKpdNyIJaSa5JpA8eMJiEKVsSkClRT5tA==",
+      "requires": {
+        "tslib": "^1.7.1"
+      }
+    },
     "@angular/platform-browser": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-7.1.4.tgz",

--- a/plugin/app/package.json
+++ b/plugin/app/package.json
@@ -23,6 +23,7 @@
     "@angular/forms": "^7.1.0",
     "@angular/http": "^7.1.0",
     "@angular/material": "^7.1.0",
+    "@angular/material-moment-adapter": "^7.1.0",
     "@angular/platform-browser": "^7.1.0",
     "@angular/platform-browser-dynamic": "^7.1.0",
     "@angular/router": "^7.1.0",

--- a/plugin/app/src/app/athlete-settings/components/dated-athlete-settings-manager/models/dated-athlete-settings-table.model.ts
+++ b/plugin/app/src/app/athlete-settings/components/dated-athlete-settings-manager/models/dated-athlete-settings-table.model.ts
@@ -12,7 +12,7 @@ export class DatedAthleteSettingsTableModel extends DatedAthleteSettingsModel {
 			datedAthleteSettingsModel
 		);
 
-		this.sinceAsDate = (this.since) ? new Date(this.since) : null;
+		this.sinceAsDate = (this.since) ? moment(this.since).toDate() : null;
 		this.untilAsDate = (previousDatedAthleteSettingsModel && previousDatedAthleteSettingsModel.since) ?
 			moment(previousDatedAthleteSettingsModel.since, DatedAthleteSettingsModel.SINCE_DATE_FORMAT).subtract(1, "days").toDate() : null;
 	}

--- a/plugin/app/src/app/athlete-settings/components/edit-dated-athlete-settings-dialog/edit-dated-athlete-settings-dialog.component.ts
+++ b/plugin/app/src/app/athlete-settings/components/edit-dated-athlete-settings-dialog/edit-dated-athlete-settings-dialog.component.ts
@@ -1,5 +1,7 @@
 import { Component, Inject, OnInit } from "@angular/core";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material";
+import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
+import { MomentDateAdapter, MAT_MOMENT_DATE_FORMATS } from "@angular/material-moment-adapter";
 import { DatedAthleteSettingsModel } from "@elevate/shared/models";
 import * as moment from "moment";
 import { DatedAthleteSettingsDialogData } from "./dated-athlete-settings-dialog-data.model";
@@ -9,7 +11,11 @@ import * as _ from "lodash";
 @Component({
 	selector: "app-edit-dated-athlete-settings-dialog",
 	templateUrl: "./edit-dated-athlete-settings-dialog.component.html",
-	styleUrls: ["./edit-dated-athlete-settings-dialog.component.scss"]
+	styleUrls: ["./edit-dated-athlete-settings-dialog.component.scss"],
+	providers: [
+		{provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]},
+		{provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS},
+	]
 })
 export class EditDatedAthleteSettingsDialogComponent implements OnInit {
 


### PR DESCRIPTION
Here's a stab at fixing #705.  Hopefully there are tests around the dates that can catch if anything has broken due to incorrect date storage.

Resources:
https://blog.angular.io/taking-advantage-of-the-angular-material-datepicker-237e80fa14b3
https://material.angular.io/components/datepicker/examples