### PR TITLE
Replace the chain of replacements with a single regex to do the same

### DIFF
--- a/plugin/core/scripts/modifiers/hide-feed.modifier.ts
+++ b/plugin/core/scripts/modifiers/hide-feed.modifier.ts
@@ -54,11 +54,8 @@ export class HideFeedModifier extends AbstractModifier {
 
 					const activityType: string = $(element)
 						.find("div.entry-icon.media-left").find(".app-icon").attr("class")
-						.replace("app-icon", "")
-						.replace("icon-dark", "")
-						.replace("icon-lg", "")
-						.replace(/\s+/g, "")
-						.replace("icon-", "");
+						// extract the activityType from the first class with icon-<activityType>, ignoring icon-lg and icon-dark
+						.replace(/^.*icon-(?!lg|dark)([^ ]+).*$/, "$1");
 
 					const distanceElement = _.filter($(element).find("ul.list-stats").find("[class=unit]"), (item) => {
 						return ($(item).html().trim() == "km" || $(item).html().trim() == "mi");


### PR DESCRIPTION
Though this regex is less readable than replacements chain, it is more durable.  If Strava (or another browser extension) modifies the classes on that element, this will replace any classes which don't begin with "icon-" (as well as replace icon-lg and icon-dark).

Unfortunately, the regex will still have to be updated if Strava adds new "icon-" classes.  There's also no way to account for other "icon-" classes added by other extensions, so lets hope "icon-<activityType>" comes before those others.