### PR TITLE
Update FitnessTrend on window:focus, acting like onGraphMouseOut

### DIFF
--- a/plugin/app/src/app/fitness-trend/fitness-trend-graph/fitness-trend-graph.component.html
+++ b/plugin/app/src/app/fitness-trend/fitness-trend-graph/fitness-trend-graph.component.html
@@ -25,6 +25,7 @@
 
 		<div #fitnessTrendGraph id="fitnessTrendGraph" class="viewed-day-tooltip"
 			 [ngClass]='{"active-viewed-day": viewedDay?.hasActivities()}'
+			 (window:focus)="setTodayAsViewedDay()"
 			 (document:mousemove)="onTooltipMouseMove($event)">
 
 			<!--Tooltip shown on mouse move over graph-->


### PR DESCRIPTION
A minor enhancement so the FitnessTrend will update on window:focus.  

I noticed that I was frequently confused/annoyed if I switched to the pinned Elevate tab and it displayed a different day (whenever I last viewed the tab) as "Today, Thursday, January 10th 2019".  This PR doesn't add much (only one line, in fact), but switching to a tab with FitnessTrend open will set today as the viewed day (like `onGraphMouseOut()`) and update the legend accordingly.