### PR TITLE
RSS for manual runs, fixes #733

### DIFF
--- a/plugin/core/scripts/models/compute-activity-thread-message.model.ts
+++ b/plugin/core/scripts/models/compute-activity-thread-message.model.ts
@@ -14,4 +14,6 @@ export class ComputeActivityThreadMessageModel {
 	activityStream: ActivityStreamsModel;
 	bounds: number[];
 	returnZones: boolean;
+    elapsed_time: number;
+    average_speed: number;
 }

--- a/plugin/core/scripts/processors/activity-computer.ts
+++ b/plugin/core/scripts/processors/activity-computer.ts
@@ -527,9 +527,9 @@ export class ActivityComputer {
 	 */
 	protected moveData(velocityArray: number[], timeArray: number[], gradeAdjustedSpeedArray?: number[]): MoveDataModel {
 
-    if (_.isEmpty(velocityArray) || _.isEmpty(timeArray)) {
-        return null;
-    }
+        if (_.isEmpty(velocityArray) || _.isEmpty(timeArray)) {
+            return null;
+        }
 
 		let genuineAvgSpeedSum = 0,
 			genuineAvgSpeedSecondsSum = 0;

--- a/plugin/core/scripts/processors/activity-computer.ts
+++ b/plugin/core/scripts/processors/activity-computer.ts
@@ -52,6 +52,8 @@ export class ActivityComputer {
 	protected activityStream: ActivityStreamsModel;
 	protected bounds: number[];
 	protected returnZones: boolean;
+    protected elapsed_time: number;
+    protected average_speed: number;
 
 	constructor(activityType: string,
 				isTrainer: boolean,
@@ -62,7 +64,9 @@ export class ActivityComputer {
 				activityStatsMap: ActivityStatsMapModel,
 				activityStream: ActivityStreamsModel,
 				bounds: number[],
-				returnZones: boolean) {
+                returnZones: boolean,
+                elapsed_time: number,
+                average_speed: number) {
 
 		// Store activityType, isTrainer, input activity params and userSettingsData
 		this.activityType = activityType;
@@ -76,6 +80,8 @@ export class ActivityComputer {
 		this.activityStream = activityStream;
 		this.bounds = bounds;
 		this.returnZones = returnZones;
+        this.elapsed_time = elapsed_time;
+        this.average_speed = average_speed;
 	}
 
 	public static streamVariationsSplits(trackedStream: number[], timeScale: number[], distanceScale: number[]): StreamVariationSplit[] {
@@ -197,9 +203,7 @@ export class ActivityComputer {
 
 	public compute(): AnalysisDataModel {
 
-		if (!this.activityStream) {
-			return null;
-		}
+    if (!_.isNull(this.activityStream)) {
 
 		// Append altitude_smooth to fetched strava activity stream before compute analysis data
 		this.activityStream.altitude_smooth = this.smoothAltitudeStream(this.activityStream, this.activityStatsMap);
@@ -208,7 +212,10 @@ export class ActivityComputer {
 		// It's mainly used for segment effort extended stats
 		this.sliceStreamFromBounds(this.activityStream, this.bounds);
 
-		return this.computeAnalysisData(this.athleteModel, this.hasPowerMeter, this.activityStatsMap, this.activityStream);
+    }
+
+	return this.computeAnalysisData(this.athleteModel, this.hasPowerMeter, this.activityStatsMap, this.activityStream);
+
 	}
 
 	protected sliceStreamFromBounds(activityStream: ActivityStreamsModel, bounds: number[]): void {
@@ -277,9 +284,14 @@ export class ActivityComputer {
 		// Include speed and pace
 		this.movementData = null;
 
-		if (activityStream.velocity_smooth) {
-			this.movementData = this.moveData(activityStream.velocity_smooth, activityStream.time, activityStream.grade_adjusted_speed);
-		}
+        if (activityStream) {
+            if (activityStream.velocity_smooth) {
+		  	    this.movementData = this.moveData(activityStream.velocity_smooth, activityStream.time, activityStream.grade_adjusted_speed);
+            }
+        }
+        else if (this.activityType === "Run") {
+            this.movementData = this.moveDataEstimate(this.elapsed_time, this.average_speed);
+        }
 
 		// Q1 Speed
 		// Median Speed
@@ -321,16 +333,16 @@ export class ActivityComputer {
 		// Q1 HR
 		// Median HR
 		// Q3 HR
-		const heartRateData: HeartRateDataModel = this.heartRateData(athleteModel, activityStream.heartrate, activityStream.time, activityStream.velocity_smooth);
+		const heartRateData: HeartRateDataModel = (!_.isNull(activityStream)) ? this.heartRateData(athleteModel, activityStream.heartrate, activityStream.time, activityStream.velocity_smooth) : null;
 
 		// Avg grade
 		// Q1/Q2/Q3 grade
-		const gradeData: GradeDataModel = this.gradeData(activityStream.grade_smooth, activityStream.velocity_smooth, activityStream.time, activityStream.distance, activityStream.cadence);
+		const gradeData: GradeDataModel = (!_.isNull(activityStream)) ? this.gradeData(activityStream.grade_smooth, activityStream.velocity_smooth, activityStream.time, activityStream.distance, activityStream.cadence) : null;
 
 		// Cadence percentage
 		// Time Cadence
 		// Crank revolution
-		const cadenceData: CadenceDataModel = this.cadenceData(activityStream.cadence, activityStream.velocity_smooth, activityStream.distance, activityStream.time);
+		const cadenceData: CadenceDataModel = (!_.isNull(activityStream)) ? this.cadenceData(activityStream.cadence, activityStream.velocity_smooth, activityStream.distance, activityStream.time) : null;
 		// ... if exists cadenceData then append cadence pace (climbing, flat & downhill) if she has been previously provided by "gradeData"
 		if (cadenceData && gradeData && gradeData.upFlatDownCadencePaceData) {
 			cadenceData.upFlatDownCadencePaceData = gradeData.upFlatDownCadencePaceData;
@@ -356,6 +368,10 @@ export class ActivityComputer {
 	}
 
 	protected estimatedRunningPower(activityStream: ActivityStreamsModel, athleteWeight: number, hasPowerMeter: boolean, userFTP: number) {
+
+        if (_.isNull(activityStream)) {
+            return null;
+        }
 
 		try {
 			console.log("Trying to estimate wattage of this run...");
@@ -447,6 +463,63 @@ export class ActivityComputer {
 
 	/**
 	 *
+	 * @param {number} elapsed_time
+	 * @param {number} average_speed
+	 * @returns {MoveDataModel}
+	 */
+	protected moveDataEstimate(elapsed_time: number, average_speed: number): MoveDataModel {
+
+        if (elapsed_time == null || average_speed == null || elapsed_time === 0) {
+            return null;
+        }
+
+		const genuineAvgSpeed: number = average_speed * 3.6;
+
+		const speedData: SpeedDataModel = {
+			genuineAvgSpeed: genuineAvgSpeed,
+			totalAvgSpeed: genuineAvgSpeed,
+            best20min: (elapsed_time >= 1200) ? genuineAvgSpeed : null,
+			avgPace: Math.floor((1 / genuineAvgSpeed) * 60 * 60), // send in seconds
+			lowerQuartileSpeed: genuineAvgSpeed,
+			medianSpeed: genuineAvgSpeed,
+			upperQuartileSpeed: genuineAvgSpeed,
+			varianceSpeed: 0,
+			genuineGradeAdjustedAvgSpeed: genuineAvgSpeed,
+			standardDeviationSpeed: 0,
+			speedZones: null
+		};
+
+		const genuineAvgPace = Math.floor(this.convertSpeedToPace(genuineAvgSpeed));
+
+		const runningStressScore = (this.activityType === "Run" && genuineAvgPace && this.athleteModel.athleteSettings.runningFtp)
+        ? ActivityComputer.computeRunningStressScore(elapsed_time, genuineAvgPace, this.athleteModel.athleteSettings.runningFtp) : null;
+
+		const paceData: PaceDataModel = {
+			avgPace: Math.floor((1 / genuineAvgSpeed) * 60 * 60), // send in seconds
+            best20min: (elapsed_time >= 1200) ? Math.floor((1 / genuineAvgSpeed) * 60 * 60) : null,
+			lowerQuartilePace: genuineAvgPace,
+			medianPace: genuineAvgPace,
+			upperQuartilePace: genuineAvgPace,
+			variancePace: 0,
+			genuineGradeAdjustedAvgPace: genuineAvgPace,
+			paceZones: null,
+			gradeAdjustedPaceZones: null,
+			runningStressScore: runningStressScore,
+			runningStressScorePerHour: (runningStressScore) ? runningStressScore / elapsed_time * 60 * 60 : null
+		};
+
+		const moveData: MoveDataModel = {
+			movingTime: elapsed_time,
+			elapsedTime: elapsed_time,
+			speed: speedData,
+			pace: paceData,
+		};
+
+		return moveData;
+	}
+
+	/**
+	 *
 	 * @param {number[]} velocityArray
 	 * @param {number[]} timeArray
 	 * @param {number[]} gradeAdjustedSpeedArray
@@ -454,9 +527,9 @@ export class ActivityComputer {
 	 */
 	protected moveData(velocityArray: number[], timeArray: number[], gradeAdjustedSpeedArray?: number[]): MoveDataModel {
 
-		if (_.isEmpty(velocityArray) || _.isEmpty(timeArray)) {
-			return null;
-		}
+    if (_.isEmpty(velocityArray) || _.isEmpty(timeArray)) {
+        return null;
+    }
 
 		let genuineAvgSpeedSum = 0,
 			genuineAvgSpeedSecondsSum = 0;
@@ -574,7 +647,7 @@ export class ActivityComputer {
 		const genuineGradeAdjustedAvgPace = (hasGradeAdjustedSpeed) ? Math.floor(this.convertSpeedToPace(genuineGradeAdjustedAvgSpeed)) : null;
 
 		const runningStressScore = (this.activityType === "Run" && genuineGradeAdjustedAvgPace && this.athleteModel.athleteSettings.runningFtp)
-			? ActivityComputer.computeRunningStressScore(this.activityStatsMap.movingTime, genuineGradeAdjustedAvgPace, this.athleteModel.athleteSettings.runningFtp) : null;
+            ? ActivityComputer.computeRunningStressScore(this.activityStatsMap.movingTime, genuineGradeAdjustedAvgPace, this.athleteModel.athleteSettings.runningFtp) : null;
 
 		const paceData: PaceDataModel = {
 			avgPace: Math.floor((1 / genuineAvgSpeed) * 60 * 60), // send in seconds
@@ -1177,6 +1250,10 @@ export class ActivityComputer {
 	}
 
 	protected elevationData(activityStream: ActivityStreamsModel): ElevationDataModel {
+
+        if (_.isNull(activityStream)) {
+            return null;
+        }
 
 		const distanceArray: any = activityStream.distance;
 		const timeArray: any = activityStream.time;

--- a/plugin/core/scripts/processors/activity-processor.ts
+++ b/plugin/core/scripts/processors/activity-processor.ts
@@ -145,7 +145,9 @@ export class ActivityProcessor {
 			activityStatsMap: activityStatsMap,
 			activityStream: activityStream,
 			bounds: bounds,
-			returnZones: true
+            returnZones: true,
+            elapsed_time: null,
+            average_speed: null
 		};
 
 		this.computeAnalysisThread.postMessage(threadMessage);

--- a/plugin/core/scripts/processors/multiple-activity-processor.ts
+++ b/plugin/core/scripts/processors/multiple-activity-processor.ts
@@ -144,7 +144,9 @@ export class MultipleActivityProcessor {
 			activityStatsMap: activityStatsMap,
 			activityStream: activityWithStream.stream,
 			bounds: null,
-			returnZones: false
+            returnZones: false,
+            elapsed_time: activityWithStream.elapsed_time_raw,
+            average_speed: activityWithStream.distance_raw / activityWithStream.elapsed_time_raw
 		};
 
 		computeAnalysisThread.postMessage(threadMessage);

--- a/plugin/core/scripts/processors/workers/compute-analysis.worker.ts
+++ b/plugin/core/scripts/processors/workers/compute-analysis.worker.ts
@@ -16,7 +16,9 @@ onmessage = (mainThreadEvent: MessageEvent) => {
 		threadMessage.activityStatsMap,
 		threadMessage.activityStream,
 		threadMessage.bounds,
-		threadMessage.returnZones);
+        threadMessage.returnZones,
+        threadMessage.elapsed_time,
+        threadMessage.average_speed);
 	const result: AnalysisDataModel = analysisComputer.compute();
 
 	postMessage(result);

--- a/plugin/core/specs/processors/activity-computing/activity-computer-pace.spec.ts
+++ b/plugin/core/specs/processors/activity-computing/activity-computer-pace.spec.ts
@@ -35,6 +35,8 @@ describe("ActivityComputer Paces", () => {
 	const userSettingsMock: UserSettingsModel = _.cloneDeep(require("../../fixtures/user-settings/2470979.json")); // Thomas C user settings
 	const statsMap: ActivityStatsMapModel = _.cloneDeep(require("../../fixtures/activities/887284960/statsMap.json"));
 	const athleteModel = new AthleteModel(Gender.MEN, new AthleteSettingsModel(200, 45, null, 240, null, null, 71.9));
+    const elapsed_time = null;
+    const average_speed = null;
 
 	const PACE_SECONDS_TOLERANCE = 10;
 
@@ -45,7 +47,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -63,7 +65,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -81,7 +83,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -99,7 +101,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -117,7 +119,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -135,7 +137,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -153,7 +155,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -171,7 +173,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -189,7 +191,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -207,7 +209,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -225,7 +227,7 @@ describe("ActivityComputer Paces", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then

--- a/plugin/core/specs/processors/activity-computing/activity-computer-power.spec.ts
+++ b/plugin/core/specs/processors/activity-computing/activity-computer-power.spec.ts
@@ -34,6 +34,8 @@ describe("ActivityComputer Cycling Power", () => {
 		movingTime: -1,
 		elevation: -1
 	};
+    const elapsed_time = null;
+    const average_speed = null;
 
 	let TOLERANCE;
 
@@ -52,7 +54,7 @@ describe("ActivityComputer Cycling Power", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -72,7 +74,7 @@ describe("ActivityComputer Cycling Power", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -96,7 +98,7 @@ describe("ActivityComputer Cycling Power", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -116,7 +118,7 @@ describe("ActivityComputer Cycling Power", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -136,7 +138,7 @@ describe("ActivityComputer Cycling Power", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -158,7 +160,7 @@ describe("ActivityComputer Cycling Power", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -178,7 +180,7 @@ describe("ActivityComputer Cycling Power", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then
@@ -199,7 +201,7 @@ describe("ActivityComputer Cycling Power", () => {
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 		const result: AnalysisDataModel = activityComputer.compute();
 
 		// Then

--- a/plugin/core/specs/processors/activity-computing/activity-computer.spec.ts
+++ b/plugin/core/specs/processors/activity-computing/activity-computer.spec.ts
@@ -60,7 +60,7 @@ describe("ActivityComputer", () => {
 
 		const isActivityAuthor = true;
 		const activityComputer: ActivityComputer = new ActivityComputer("Ride", powerMeter, userSettingsMock, athleteModel,
-			isActivityAuthor, powerMeter, statsMap, stream, null, true);
+			isActivityAuthor, powerMeter, statsMap, stream, null, true, null, null);
 
 		const result: AnalysisDataModel = activityComputer.compute();
 

--- a/plugin/core/specs/processors/running-power-estimator.spec.ts
+++ b/plugin/core/specs/processors/running-power-estimator.spec.ts
@@ -244,10 +244,12 @@ describe("RunningPowerEstimator", () => {
 		const stream: ActivityStreamsModel = _.cloneDeep(require("../fixtures/activities/887284960/stream.json"));
 		const statsMap: ActivityStatsMapModel = _.cloneDeep(require("../fixtures/activities/887284960/statsMap.json"));
 		const athleteModel = new AthleteModel(Gender.MEN, new AthleteSettingsModel(200, 45, null, 240, null, null, 71.9));
+        const elapsed_time = null;
+        const average_speed = null;
 
 		// When
 		const activityComputer: ActivityComputer = new ActivityComputer(activityType, isTrainer, userSettingsMock, athleteModel,
-			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones);
+			isActivityAuthor, hasPowerMeter, statsMap, stream, bounds, returnZones, elapsed_time, average_speed);
 
 		const result: AnalysisDataModel = activityComputer.compute();
 


### PR DESCRIPTION
This addresses #733 and #663 by computing the RSS for a manually entered run.

Several classes (ActivityComputer, ActivityProcessor, ComputeActivityThreadMessageModel, MultipleActivityProcessor) now take a time and average speed separately from the activity stream, calculated from the elapsed_time_raw and distance_raw that are returned in the original activity request from the server. There may be a better way to do this; feel free to use whatever is helpful.