### PR TITLE
Fix running hr

### DIFF
--- a/plugin/core/scripts/modifiers/segment-recent-efforts-hratime.modifier.ts
+++ b/plugin/core/scripts/modifiers/segment-recent-efforts-hratime.modifier.ts
@@ -100,8 +100,8 @@ export class SegmentRecentEffortsHRATimeModifier extends AbstractModifier {
 			};
 
 			// scan area used by the effort marks
-			let maxY: number, minY: number;
-			let minX: number, maxX: number;
+			let maxY: number = null, minY: number = null;
+			let minX: number = null, maxX: number = null;
 			marks.each((i, m) => {
 				const xy = xyFromMark(m);
 				minY = Helper.safeMin(minY, xy.y);


### PR DESCRIPTION
The Beta feature "Display running estimated paces & cycling estimated powers from most painful effort on a segment (Experimental)" was broken since 5625f9bc56f6b1facfbc8e58d8be1dc487e847d0, as `safeMin`/`safeMax`  no longer worked for uninitialized values.

This is a trivial fix of the issue.