### PR TITLE
Fix stress score discrepancy

### DIFF
--- a/plugin/app/src/app/fitness-trend/shared/models/day-stress.model.ts
+++ b/plugin/app/src/app/fitness-trend/shared/models/day-stress.model.ts
@@ -28,27 +28,27 @@ export class DayStressModel {
 	}
 
 	public printHeartRateStressScore(): string {
-		return (this.heartRateStressScore) ? Math.floor(this.heartRateStressScore).toString() : "-";
+		return (this.heartRateStressScore) ? Math.round(this.heartRateStressScore).toString() : "-";
 	}
 
 	public printTrainingImpulseScore(): string {
-		return (this.trainingImpulseScore) ? Math.floor(this.trainingImpulseScore).toString() : "-";
+		return (this.trainingImpulseScore) ? Math.round(this.trainingImpulseScore).toString() : "-";
 	}
 
 	public printPowerStressScore(): string {
-		return (this.powerStressScore) ? Math.floor(this.powerStressScore).toString() : "-";
+		return (this.powerStressScore) ? Math.round(this.powerStressScore).toString() : "-";
 	}
 
 	public printRunningStressScore(): string {
-		return (this.runningStressScore) ? Math.floor(this.runningStressScore).toString() : "-";
+		return (this.runningStressScore) ? Math.round(this.runningStressScore).toString() : "-";
 	}
 
 	public printSwimStressScore(): string {
-		return (this.swimStressScore) ? Math.floor(this.swimStressScore).toString() : "-";
+		return (this.swimStressScore) ? Math.round(this.swimStressScore).toString() : "-";
 	}
 
 	public printFinalStressScore(): string {
-		return (this.finalStressScore) ? Math.floor(this.finalStressScore).toString() : "-";
+		return (this.finalStressScore) ? Math.round(this.finalStressScore).toString() : "-";
 	}
 
 


### PR DESCRIPTION
The discrepancy in stress score values between the Fitness Trend and Activities pages is due to the use of floor() in Fitness Trend and round() in Activities. I'm sure when first creating the program there was some reasoning behind using floor() on the Fitness Trend page, but changing to round() was the easiest solution of the three:
1) Modify the stress calculation at the source (activity-computer) to output a number with no decimals (rounded, or floored) - pretty simple but I don't think the after effects (losing precision for future calculations) would be worth it.
2) Modify the Activities table namespace to write a custom detection for stress scores to floor() the values instead of round() - pretty roundabout and involved due to how the namespace and table is programmed already
3) Modify the Fitness Trend and day stress model to round() instead of floor() - easiest and most practical: it passes all of the unit tests without modifying the tests

Ultimately, one has to weigh the decision between floor() and round() for these values, and I decided that round() would produce a more appropriate value. If people are looking at the stress scores to calculate weekly TSS to plan training around, 1 stress point here and there is still just a rounding issue (pun intended), but I feel as though _overestimating_ stress would result in less potential for overload than underestimating stress.

Fixes #961 if merged.